### PR TITLE
Install all packages in setuptools script

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,4 +1,4 @@
-from setuptools import setup
+from setuptools import setup, find_packages
 
 try:
     with open("README.md") as f:
@@ -15,7 +15,7 @@ def _get_version():
 setup(
     name="soulstruct",
     version=_get_version(),
-    packages=["soulstruct"],
+    packages=find_packages(),
     description="Inspect and mod FromSoftware games.",
     long_description=long_description,
     extras_require={


### PR DESCRIPTION
Previously only the root `soulstruct` namespace was being installed by
the setuptools package, this meant all the individual game packages were
missing. This change uses `find_packages()` from setuptools to find all
relevant packages to put into the archive.