### PR TITLE
Fix for PTDE import error

### DIFF
--- a/soulstruct/darksouls1ptde/project/core.py
+++ b/soulstruct/darksouls1ptde/project/core.py
@@ -31,7 +31,7 @@ class GameDirectoryProject(_BaseGameDirectoryProject, DarkSoulsPTDEType):
         "text": MSGDirectory,
     }
 
-    def initialize_project(self, force_import_from_game=False, with_window: ProjectWindow = None):
+    def initialize_project(self, force_import_from_game=False, with_window: ProjectWindow = None, **kwargs):
         self._check_ptde_unpacked()
         super().initialize_project(force_import_from_game, with_window)
 


### PR DESCRIPTION
Added **kwargs to the function, it throws a TypeError otherwise:
```
  ERROR :: 2021-07-25 21:07:42,697 :: soulstruct.base.project.window :: Line  120 :: Fatal internal error encountered. Aborting startup.
Traceback (most recent call last):
  File "C:\Users\sawal\Downloads\soulstruct\soulstruct\base\project\window.py", line 107, in __init__
    self.project = self.PROJECT_CLASS(project_path, with_window=self)
  File "C:\Users\sawal\Downloads\soulstruct\soulstruct\base\project\core.py", line 109, in __init__
    self.initialize_project(force_import_from_game, with_window=with_window, first_time=first_time)
TypeError: initialize_project() got an unexpected keyword argument 'first_time'
  ERROR :: 2021-07-25 21:07:45,975 :: soulstruct :: Line  244 :: Error occurred in soulstruct.__main__: initialize_project() got an unexpected keyword argument 'first_time'
Traceback (most recent call last):
  File "C:\Users\sawal\Downloads\soulstruct\soulstruct\__main__.py", line 242, in <module>
    launch_interactive = soulstruct_main(parser.parse_args())
  File "C:\Users\sawal\Downloads\soulstruct\soulstruct\__main__.py", line 236, in soulstruct_main
    window = game.import_game_submodule("project").ProjectWindow(source)
  File "C:\Users\sawal\Downloads\soulstruct\soulstruct\base\project\window.py", line 107, in __init__
    self.project = self.PROJECT_CLASS(project_path, with_window=self)
  File "C:\Users\sawal\Downloads\soulstruct\soulstruct\base\project\core.py", line 109, in __init__
    self.initialize_project(force_import_from_game, with_window=with_window, first_time=first_time)
TypeError: initialize_project() got an unexpected keyword argument 'first_time'
```