### PR TITLE
fix case of `DEFAULT_PROJECT_PATH` kwarg

### DIFF
--- a/soulstruct/base/project/window.py
+++ b/soulstruct/base/project/window.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+from soulstruct.config import DEFAULT_PROJECT_PATH
+
 __all__ = ["ProjectWindow"]
 
 import abc
@@ -781,13 +783,13 @@ class ProjectWindow(SmartFrame, abc.ABC):
         """Set this project directory as the Soulstruct default in `config.py`."""
         from soulstruct.config import SET_CONFIG
 
-        SET_CONFIG(default_project_path=str(self.project.project_root))
+        SET_CONFIG(DEFAULT_PROJECT_PATH=str(self.project.project_root))
 
     @staticmethod
     def _clear_default_project():
         from soulstruct.config import SET_CONFIG
 
-        SET_CONFIG(default_project_path="")
+        SET_CONFIG(DEFAULT_PROJECT_PATH="")
 
     def _create_game_backup(self):
         backup_path = self.project.game_root / "soulstruct-backup"


### PR DESCRIPTION
Because the kwarg being passed to `SET_CONFIG` was all lowercase but the attribute was defined as all caps in `config.py`, trying to set (or clear) the default project would result in a KeyError [here](https://github.com/Grimrukh/soulstruct/blob/6c42ccc7191e22985bd94c679e6824742af85179/soulstruct/config.py#L82). Simply fixing the case causes this behavior to function as expected.