### PR TITLE
add item_type kwarg to Item tests

### DIFF
--- a/soulstruct/base/events/emevd/tests.py
+++ b/soulstruct/base/events/emevd/tests.py
@@ -338,11 +338,12 @@ def PlayerBeyondDistance(entity: CoordEntityTyping, min_distance, condition, neg
 
 
 @negate_only
-def HasItem(item: ItemTyping, condition, negate=False):
-    try:
-        item_type = item.item_enum
-    except AttributeError:
-        raise ValueError("Can only use auto-detecting HasItem() on declared item types (Weapon, Armor, Ring, Good).")
+def HasItem(item: ItemTyping, condition, item_type=None, negate=False):
+    if item_type is None:
+        try:
+            item_type = item.item_enum
+        except AttributeError:
+            raise ValueError("Can only use auto-detecting HasItem() on declared item types (Weapon, Armor, Ring, Good).")
     return instr.IfPlayerItemStateNoBox(condition, item_type, item, not negate)
 
 
@@ -430,20 +431,22 @@ def AnyItemDroppedInRegion(region: Region, condition):
 
 
 @no_skip_or_negate_or_return
-def ItemDropped(item: ItemTyping, condition):
-    try:
-        item_type = item.item_enum
-    except AttributeError:
-        raise ValueError("Can only use HasItem() on declared item types (Weapon, Armor, Ring, Good).")
+def ItemDropped(item: ItemTyping, condition, item_type=None):
+    if item_type is None:
+        try:
+            item_type = item.item_enum
+        except AttributeError:
+            raise ValueError("Can only use ItemDropped() on declared item types (Weapon, Armor, Ring, Good).")
     return instr.IfItemDropped(condition, item, item_type)
 
 
 @negate_only
-def OwnsItem(item: ItemTyping, condition, negate=False):
-    try:
-        item_type = item.type
-    except AttributeError:
-        raise ValueError("Can only use OwnsItem() on declared item types (Weapon, Armor, Ring, Good).")
+def OwnsItem(item: ItemTyping, condition, item_type=None, negate=False):
+    if item_type is None:
+        try:
+            item_type = item.type
+        except AttributeError:
+            raise ValueError("Can only use OwnsItem() on declared item types (Weapon, Armor, Ring, Good).")
     return instr.IfPlayerItemStateBox(condition, item_type, item, not negate)
 
 


### PR DESCRIPTION
(duplicate of #12 , moved to different branch)

Currently, no syntax exists for specifying `item_type`s to the `HasItem`, `ItemDropped`, and `OwnsItem` tests. However, when using arbitrary `item_type`s (ie, when the item type is passed into an event via argument), the more specific tests like `HasWeapon`, `HasGood`, etc. cannot be used either:

![problem](https://user-images.githubusercontent.com/20602720/130865123-2219905e-0816-4f41-a482-769cbf4ef1d4.png)

I can think of two ways to circumvent this already. One alternative is to create identical events that have the different item types hardcoded into them, and call these different events depending on the desired `item_type`. This is undesirable, especially if the event is already complex - at worst this approach requires four different events that are syntactically identical except for one constant. The other alternative is to use the `IfPlayerHasItem`, `IfPlayerOwnsItem`, or `IfItemDropped` instructions directly, which makes using explicit condition groups necessary - and to quote [example_with_comments.py](https://github.com/Grimrukh/soulstruct/blob/3c94ae477b23bff6a19ac03d8f11923ab6795f10/examples/example_with_comments.py#L254-L255), "The whole point is that you never have to manually build a condition or calculate a line skip again."

Using the changes I'm requesting, Soulstruct is able to successfully compile and decompile the desired syntax into logically equivalent instructions, as shown below (the desired syntax version uses condition group 7, and the original syntax uses condition group 2):

![solution](https://user-images.githubusercontent.com/20602720/130866182-e924f851-57be-4692-84fb-e102d4ca54d3.png)

There seems to be some logic for extracting the `item_type` from the `item` argument within the tests. However, I couldn't figure out how to make use of this myself, considering that the `item` argument being passed in is also arbitrary (passed into the event via argument). I also couldn't find any examples of this being used, in the provided example file nor in the StJudeSouls repo - I'm not sure where to look besides these places. 

I could be missing something obvious as to why this syntax was written as it is now - please let me know if this is the case. Thank you!

sidenote - I'm not sure what the desired format for contributions is - consider [adding contributor guidelines](https://docs.github.com/en/communities/setting-up-your-project-for-healthy-contributions/setting-guidelines-for-repository-contributors) to the repo!