### PR TITLE
replace DS1 `EventArg` `HEADER_STRUCT`'s 4x padding with "unknown" field

### DIFF
--- a/soulstruct/darksouls1ptde/events/emevd/core.py
+++ b/soulstruct/darksouls1ptde/events/emevd/core.py
@@ -31,7 +31,7 @@ class EventArg(_BaseEventArg):
         ("write_from_byte", "I"),
         ("read_from_byte", "I"),
         ("bytes_to_write", "I"),
-        "4x",
+        ("unknown", "i"),
     )
 
 


### PR DESCRIPTION
With the new Elden Ring commits, the base `EventArg` class began passing the [`UnkID`](https://github.com/JKAnderson/SoulsFormats/blob/106e54ac414240b05d4fb5db92863beecbc87dec/SoulsFormats/Formats/EMEVD/Parameter.cs#L30-L33) field into its `HEADER_STRUCT`'s `pack` function to generate the `EventArg`'s binary representation. [Here's the commit where this change happened.](https://github.com/Grimrukh/soulstruct/commit/3283f832da5810f64e62f693ce35d0952fca79ad#diff-7a8a3ebe3e06e5f4fb23221f7c62834fa0ec0cedb532d511b1b0897061db0993).

For Dark Souls 3 and Elden Ring, the base `EventArg`'s `HEADER_STRUCT` is overridden with a `BinaryStruct` that includes the `UnkID` as an int field called `unknown`. However,[ the Dark Souls 1 `EventArg` `HEADER_STRUCT` does not have the unknown field - instead, those four bytes are treated as a 4x padding field](https://github.com/Grimrukh/soulstruct/blob/6599de2dc0fb904e33f2706c5cc3578aba2476f0/soulstruct/darksouls1ptde/events/emevd/core.py#L34).

I suspect that this is because, as SoulsFormat confirms, these bytes were always zeroed out in every game before Sekiro. This shouldn't be an issue, except for `BinaryStruct`'s `pack` function [expecting there to be no extraneous keys in its input dict](https://github.com/Grimrukh/soulstruct/blob/6599de2dc0fb904e33f2706c5cc3578aba2476f0/soulstruct/utilities/binary.py#L368-L369). The input dict is compiled from the keyword args passed into `pack` - which now includes the `unknown` field as of the recent Elden Ring commits. Thus, **excluding the `unknown` field from DS1's `EventArg` `HEADER_STRUCT` causes the export process to error and fail**. The error produced confirms this: `ValueError: `BinaryStruct.pack()` input dictionary has extraneous keys: dict_keys(['unknown'])`.

This PR replaces the padding with the `unknown` field, avoiding the error and allowing the export process to succeed.

I should also note that [the Bloodborne `EventArg` class does not have the `unknown` field defined for its `HEADER_STRUCT` either](https://github.com/Grimrukh/soulstruct/blob/6599de2dc0fb904e33f2706c5cc3578aba2476f0/soulstruct/bloodborne/events/emevd/core.py#L27-L29), so trying to export Bloodborne events should break in the same way. It seems like the `bytes_to_write` should be an unsigned int and the last four bytes should be the unknown field, matching DS3 and Elden Ring. **I did not make this change** because I can not test if this is correct (I don't have a PS4 ;P).