### PR TITLE
Giving Detail Bumpmap samplers UV Scale for DS1

### DIFF
--- a/soulstruct/darksouls1ptde/models/shaders.py
+++ b/soulstruct/darksouls1ptde/models/shaders.py
@@ -136,11 +136,10 @@ class MatDef(_BaseMatDef):
         matdef = super(MatDef, cls).from_mtd_name(mtd_name)
 
         if matdef.get_sampler_with_alias("Main 0 Normal"):
-            # Add useless "Detail 0 Normal" sampler for completion.
+            # Add Detail 0 Normal with scaling from the mtd params if possible
             # TODO: Some DS1 shaders, even with 'g_Bumpmap', do not have this. I have no way to detect from the name.
             #  Currently assuming that it doesn't matter at all if FLVERs have an (empty) texture definition for it.
-            matdef.add_sampler(alias="Detail 0 Normal", uv_layer=cls.UVLayer.UVTexture0)
-
+            matdef.add_sampler(alias="Detail 0 Normal", uv_layer=cls.UVLayer.UVTexture0, uv_scale=matdef.mtd.get_param("g_DetailBump_UVScale", default=[1.0,1.0]))
         return matdef
 
     def get_map_piece_layout(self) -> VertexArrayLayout:

--- a/soulstruct/darksouls1r/models/shaders.py
+++ b/soulstruct/darksouls1r/models/shaders.py
@@ -8,6 +8,7 @@ from pathlib import Path
 
 from soulstruct.base.models.mtd import MTD
 from soulstruct.darksouls1ptde.models.shaders import MatDef as _PTDE_MatDef
+from soulstruct.utilities.maths import Vector2
 
 
 @dataclass(slots=True)
@@ -30,6 +31,9 @@ class MatDef(_PTDE_MatDef):
             - All FLVER vertex arrays have normals, at least one vertex color.
         """
         matdef = super(MatDef, cls).from_mtd(mtd)
+        detail_samp = matdef.get_sampler_with_alias("Detail 0 Normal")
+        if detail_samp is not None:
+            detail_samp.uv_scale = Vector2(mtd.get_param("g_DetailBump_UVScale", default=[1.0, 1.0]))
 
         if matdef.shader_category == "Snow":
             # In DS1R, some snow shaders (those with "Snow Metal Mask" MTD param) have a THIRD normal texture. I believe


### PR DESCRIPTION
Hey, this was the only change I needed to make to the main soulstruct library for my updates to the blender addon. There's a couple more things I'm thinking of doing later on, such as including texture scroll as a property of the samplers, but I figured it's better to limit the amount of changes in my PRs, especially for the main library. Feel free to edit as needed if you think there's a better way to implement this.