### PR TITLE
Updated the non-map piece vertex layout function 

### DIFF
--- a/src/soulstruct/base/models/shaders.py
+++ b/src/soulstruct/base/models/shaders.py
@@ -301,7 +301,7 @@ class MatDef(abc.ABC):
         ...
 
     @abc.abstractmethod
-    def get_non_map_piece_layout(self) -> VertexArrayLayout:
+    def get_non_map_piece_layout(self, is_bind_pose: bool = True) -> VertexArrayLayout:
         ...
 
     # endregion

--- a/src/soulstruct/bloodborne/models/shaders.py
+++ b/src/soulstruct/bloodborne/models/shaders.py
@@ -157,7 +157,7 @@ class MatDef(_BaseMatDef):
 
         return VertexArrayLayout(data_types)
 
-    def get_non_map_piece_layout(self) -> VertexArrayLayout:
+    def get_non_map_piece_layout(self, is_bind_pose: bool = True) -> VertexArrayLayout:
         """Get a standard vertex array layout for character (and probably object) materials in BB."""
 
         if len(self.samplers) == 1 and self.samplers[0].alias == "Main 0 Albedo":

--- a/src/soulstruct/darksouls1ptde/models/shaders.py
+++ b/src/soulstruct/darksouls1ptde/models/shaders.py
@@ -195,26 +195,27 @@ class MatDef(_BaseMatDef):
 
         return VertexArrayLayout(data_types)
 
-    def get_non_map_piece_layout(self) -> VertexArrayLayout:
+    def get_non_map_piece_layout(self, is_bind_pose: bool = True) -> VertexArrayLayout:
         """Get a standard vertex array layout for character (and probably object) materials in DS1."""
         data_types = [
             VertexPosition(VertexDataFormatEnum.Float3, 0),
             VertexBoneIndices(VertexDataFormatEnum.FourBytesB, 0),
-            VertexBoneWeights(VertexDataFormatEnum.FourShortsToFloats, 0),
             VertexNormal(VertexDataFormatEnum.FourBytesC, 0),
             VertexTangent(VertexDataFormatEnum.FourBytesC, 0),
             VertexColor(VertexDataFormatEnum.FourBytesC, 0),
         ]  # type: list[VertexDataType]
-
         uv_count = len(self.get_used_uv_layers())
         if uv_count == 2:  # has Bitangent and UVPair
-            data_types.insert(5, VertexBitangent(VertexDataFormatEnum.FourBytesC, 0))
+            data_types.insert(4, VertexBitangent(VertexDataFormatEnum.FourBytesC, 0))
             data_types.append(VertexUV(VertexDataFormatEnum.UVPair, 0))
         elif uv_count == 1:  # one UV
             data_types.append(VertexUV(VertexDataFormatEnum.UV, 0))
         else:
             raise ValueError(f"Invalid UV count for DS1 character layout: {uv_count}. Must be 1 or 2.")
-
+        if is_bind_pose:
+            # If the non-map piece is completely static, it might have Is Bind Pose off. In that case, bone weights
+            # need to be ignored.
+            data_types.insert(2, VertexBoneWeights(VertexDataFormatEnum.FourShortsToFloats, 0))
         for data_type in data_types:
             data_type.unk_x00 = 0  # DS1
 

--- a/src/soulstruct/darksouls2/models/shaders.py
+++ b/src/soulstruct/darksouls2/models/shaders.py
@@ -160,7 +160,7 @@ class MatDef(_BaseMatDef):
 
         return VertexArrayLayout(data_types)
 
-    def get_non_map_piece_layout(self) -> VertexArrayLayout:
+    def get_non_map_piece_layout(self, is_bind_pose: bool = True) -> VertexArrayLayout:
         """Get a standard vertex array layout for character (and probably object) materials in DS2.
 
         NOTE: Every material seems to use two colors.

--- a/src/soulstruct/demonssouls/models/shaders.py
+++ b/src/soulstruct/demonssouls/models/shaders.py
@@ -211,12 +211,11 @@ class MatDef(_BaseMatDef):
 
         return VertexArrayLayout(data_types, byte_order=ByteOrder.BigEndian)
 
-    def get_non_map_piece_layout(self) -> VertexArrayLayout:
+    def get_non_map_piece_layout(self, is_bind_pose: bool = True) -> VertexArrayLayout:
         """Get a standard vertex array layout for character (and probably object) materials in DeS."""
         data_types = [
             VertexPosition(VertexDataFormatEnum.Float3, 0),
             VertexBoneIndices(VertexDataFormatEnum.FourBytesD, 0),
-            VertexBoneWeights(VertexDataFormatEnum.FourShortsToFloats, 0),
             VertexNormal(VertexDataFormatEnum.FourBytesA, 0),
             VertexTangent(VertexDataFormatEnum.FourBytesA, 0),
             VertexColor(VertexDataFormatEnum.FourBytesA, 0),
@@ -225,13 +224,16 @@ class MatDef(_BaseMatDef):
         uv_count = len(self.get_used_uv_layers())
         if uv_count == 2:  # has Bitangent and UVPair
             # NOTE: Haven't actually seen this in DeS yet.
-            data_types.insert(5, VertexBitangent(VertexDataFormatEnum.FourBytesA, 0))
+            data_types.insert(4, VertexBitangent(VertexDataFormatEnum.FourBytesA, 0))
             data_types.append(VertexUV(VertexDataFormatEnum.UVPair, 0))
         elif uv_count == 1:  # one UV
             data_types.append(VertexUV(VertexDataFormatEnum.UV, 0))
         else:
             raise ValueError(f"Invalid UV count for DeS character layout: {uv_count}. Must be 1 or 2.")
-
+        if is_bind_pose:
+            # If the non-map piece is completely static, it might have Is Bind Pose off. In that case, bone weights
+            # need to be ignored.
+            data_types.insert(2, VertexBoneWeights(VertexDataFormatEnum.FourShortsToFloats, 0))
         for data_type in data_types:
             data_type.unk_x00 = 0  # DeS
 

--- a/src/soulstruct/eldenring/models/shaders.py
+++ b/src/soulstruct/eldenring/models/shaders.py
@@ -445,7 +445,7 @@ class MatDef(_BaseMatDef):
 
         return VertexArrayLayout(data_types)
 
-    def get_non_map_piece_layout(self) -> VertexArrayLayout:
+    def get_non_map_piece_layout(self, is_bind_pose: bool = True) -> VertexArrayLayout:
         """Get a standard vertex array layout for character (and probably object) materials in ER."""
 
         data_types = [


### PR DESCRIPTION
Updated the non-map piece vertex layout function to exclude boneweights if mesh has is_bind_pose off. Sometimes, static meshes that aren't map pieces have this off, and the models get read incorrectly if they are including bone weights in the vertices. FBX Importer has this logic of excluding the boneweights if this is off, so it seems to be the correct approach.